### PR TITLE
Fix build error and setKernelArg typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "bunyan": "~1.5.1",
     "debug": "~2.2.0",
-    "node-opencl": "mikeseven/node-opencl#69dda1c7f61bc26376013c1e89c687cdd980d373",
+    "node-opencl": "mikeseven/node-opencl",
     "q": "~1.4.1",
     "sprintf-js": "~1.0.3",
     "underscore": "~1.8.0"

--- a/src/kernel.js
+++ b/src/kernel.js
@@ -59,7 +59,7 @@ var Kernel = function (cl, name, file, argTypes) {
 
                 if (dirty) {
                     logger.trace('Setting arg %d of kernel %s to value %s', i, that.name, val);
-                    ocl.setKernelArg(kernel, i, val, type);
+                    ocl.setKernelArg(kernel, i, type, val);
                     arg.dirty = false;
                 }
             }


### PR DESCRIPTION
This fixes the build error when running `npm install` and fixes the argument order of `ocl.setKernelArg` in `src/kernel.js`.