### PR TITLE
Bump js-and-gpu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM graphistry/js-and-gpu:0.10.44
+FROM graphistry/js-and-gpu:0.10.45
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Node 0.10 is currently at 0.10.45